### PR TITLE
update travis to run tests with EXEC_BACKEND also

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,16 @@ env:
     - secure: "S8WfPsrVGg21vZPxjrmy1X19T7zpHNgaSAoqYGzJdDZcNYuZbI87+tP3VQZo4MxjP3Ag46zTI5K+6aMjCqYqFGKufZdEaSpPSLmppFbXALgSp/rOkzp1M9HhGj0QVP7QcoPbva5Bjnj3zVi9CMAo6MwtnGAvzqBLOsdtnXTxEmKYyeNgwUVbQi2nzO38GeLgabaFL4XD3f3bmHE5jG6QAwZ/L7+jajsD1biH4sOiRLCRshtvermtYxh3SK6rML2kiwATABxTd1xDdMVRO/llmDBN373tHK6mufJyIhrwG9oTprSSDDIJlEbSPCkH0uvJBGcDvOAWf9tr4TGs/beawx3ELcXqR/4EisFqvMiVL4Vpt1gMBg9gue4Y0wpHZYoBOOef2gFtuyL7PjYe9koYJAJxg9DJ29DMxIjuCLTnbHN6yLa9425pdvxcuNEJ2K2zD0ZWoLSVueL0MxLhOZJsqlMkmmrFyI7y5cj1XvJF3vcsa5yK3S7sXroKUzeLu6QMh8hO3jD/2IvdQJ7Huy5uiJk2a+KUceLzruxLbwPF4b8SEoTquJ9NFGtagCG77lbIbLltLs2fUf+JnM8ipdpoMibVRFBOahP8NZwpL/NFzG3WLH3tDncj/c3fneMiNv3FUHLf6ufOVOayQiAEidszcMct2R20qIxggXKymrjZA3k="
   matrix:
     # PG_VERSION (docker) and PG_GIT_TAG (Git) should be the same
-    - PG_VERSION=9.6.6 PG_GIT_TAG=REL9_6_6
-    - PG_VERSION=10.2 PG_GIT_TAG=REL_10_2
+    - EXEC_BACKEND=false PG_VERSION=9.6.6 PG_GIT_TAG=REL9_6_6
+    - EXEC_BACKEND=false PG_VERSION=10.2 PG_GIT_TAG=REL_10_2
+    - EXEC_BACKEND=true PG_VERSION=10
+    - EXEC_BACKEND=true PG_VERSION=9.6
 before_install:
   # We need the PostgreSQL source for running the standard PostgreSQL
   # regression tests
   - git clone --branch ${PG_GIT_TAG} --depth 1 https://github.com/postgres/postgres.git /tmp/postgres
-  - docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build -v /tmp/postgres:/postgres postgres:${PG_VERSION}-alpine
+  - if [[ "$EXEC_BACKEND" == "false" ]]; then docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build -v /tmp/postgres:/postgres postgres:${PG_VERSION}-alpine; fi
+  - if [[ "$EXEC_BACKEND" == "true" ]]; then docker run -d --name pgbuild -v ${TRAVIS_BUILD_DIR}:/build -v /tmp/postgres:/postgres jlockerman/postgres_exec_backend_images:alpine${PG_VERSION}; fi
 install:
   - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual .build-deps coreutils dpkg-dev gcc libc-dev make util-linux-dev diffutils cmake bison flex curl git && mkdir -p /build/debug"
   - docker exec -it pgbuild /bin/sh -c "apk add --no-cache --virtual --update-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted lcov"


### PR DESCRIPTION
Postgres has a compile flag EXEC_BACKEND which makes linux behave more
like windows in order to ease testing of windows behavior. By default
the postgres docker images are built without this, so we've built our
own version with the flag enabled for our CI. This commit enables
testing on those versions.

Dockerfiles used to create the images can be found [here](https://github.com/JLockerman/postgres-exec_backend-docker).