### PR TITLE
Allow downgrade to ApacheOnly license at boot

### DIFF
--- a/test/expected/edition.out
+++ b/test/expected/edition.out
@@ -20,6 +20,10 @@ SELECT _timescaledb_internal.enterprise_enabled();
 (1 row)
 
 \unset ECHO
+SET timescaledb.license_key='ApacheOnly';
+ERROR:  invalid value for parameter "timescaledb.license_key": "ApacheOnly"
+DETAIL:  Cannot downgrade a running session to Apache Only.
+HINT:  change the license in the configure file
 SELECT allow_downgrade_to_apache();
  allow_downgrade_to_apache 
 ---------------------------

--- a/test/sql/edition.sql
+++ b/test/sql/edition.sql
@@ -15,6 +15,10 @@ SELECT _timescaledb_internal.enterprise_enabled();
 
 \c :TEST_DBNAME :ROLE_SUPERUSER
 
+\set ON_ERROR_STOP 0
+SET timescaledb.license_key='ApacheOnly';
+\set ON_ERROR_STOP 1
+
 SELECT allow_downgrade_to_apache();
 SET timescaledb.license_key='ApacheOnly';
 select * from timescaledb_information.license;


### PR DESCRIPTION
We do not wish to allow users to downgrade to an ApacheOnly while the
database is running, as this would create an unusual scenario where the
TSL is linked into the running binary but not allowed to be used.
However, now that we have ts_post_load_init, there is a window at
database start when we can downgrade the license before the TSL is
loaded. This commit enables downgrading to an ApacheOnly license iff
the TSL was never loaded in the first place; the intended use is that
the user sets the license to ApacheOnly in their postgresql.conf.

NOTE: downgrading currently can have unpredictable effects.